### PR TITLE
Allow customizers to throw exceptions

### DIFF
--- a/spring-boot-warmup-core/src/main/java/dev/jeschke/spring/warmup/WarmUpCustomizer.java
+++ b/spring-boot-warmup-core/src/main/java/dev/jeschke/spring/warmup/WarmUpCustomizer.java
@@ -1,7 +1,5 @@
 package dev.jeschke.spring.warmup;
 
-import java.util.function.UnaryOperator;
-
 // @formatter:off
 /**
  * Applications can create beans implementing this interface to customize the WarmUp features.
@@ -19,4 +17,9 @@ import java.util.function.UnaryOperator;
 // @formatter:on
 @FunctionalInterface
 @SuppressWarnings("JavadocDeclaration")
-public interface WarmUpCustomizer extends UnaryOperator<WarmUpBuilder> {}
+public interface WarmUpCustomizer {
+
+    // Sonar wants a dedicated exception type, but we don't know what implementations might throw
+    @SuppressWarnings("java:S112")
+    WarmUpBuilder apply(WarmUpBuilder builder) throws Exception;
+}

--- a/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/WarmUpReadinessIndicator.java
+++ b/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/WarmUpReadinessIndicator.java
@@ -32,7 +32,14 @@ public class WarmUpReadinessIndicator extends ReadinessStateHealthIndicator {
 
     @Override
     protected AvailabilityState getState(final ApplicationAvailability applicationAvailability) {
-        final var settings = factory.getSettings(initializers);
-        return !warmUpRunner.isWarmedUp() && settings.enableReadinessIndicator() ? REFUSING_TRAFFIC : ACCEPTING_TRAFFIC;
+        try {
+            final var settings = factory.getSettings(initializers);
+            return !warmUpRunner.isWarmedUp() && settings.enableReadinessIndicator()
+                    ? REFUSING_TRAFFIC
+                    : ACCEPTING_TRAFFIC;
+        } catch (final Exception e) {
+            // Don't log here, this method might be called often. The error will be logged somewhere else
+            return ACCEPTING_TRAFFIC;
+        }
     }
 }

--- a/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/WarmUpRunner.java
+++ b/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/WarmUpRunner.java
@@ -4,11 +4,13 @@ import dev.jeschke.spring.warmup.initializers.WarmUpInitializer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WarmUpRunner {
@@ -20,8 +22,12 @@ public class WarmUpRunner {
     @Async
     @EventListener
     public void onContextRefreshed(final ContextRefreshedEvent ignoredEvent) {
-        final var settings = factory.getSettings(initializers);
-        initializers.forEach(initializer -> initializer.warmUp(settings));
+        try {
+            final var settings = factory.getSettings(initializers);
+            initializers.forEach(initializer -> initializer.warmUp(settings));
+        } catch (final Exception e) {
+            log.error("Could not execute warm up steps", e);
+        }
         done.set(true);
     }
 

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpFactoryTest.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpFactoryTest.java
@@ -50,7 +50,7 @@ class WarmUpFactoryTest {
     private WarmUpFactory factory;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         factory = new WarmUpFactory(context, httpClientBuilder);
         lenient()
                 .when(context.getBeansOfType(WarmUpCustomizer.class))
@@ -62,7 +62,7 @@ class WarmUpFactoryTest {
     }
 
     @Test
-    void getSettings() {
+    void getSettings() throws Exception {
         final var settings = factory.getSettings(List.of(initializer1, initializer2));
 
         final var inOrder = inOrder(customizer1, customizer2, initializer1, initializer2);
@@ -77,7 +77,7 @@ class WarmUpFactoryTest {
     }
 
     @Test
-    void getSettings_onlyInitializesOnce() {
+    void getSettings_onlyInitializesOnce() throws Exception {
         final var settings1 = factory.getSettings(List.of(initializer1, initializer2));
         final var settings2 = factory.getSettings(List.of(initializer1, initializer2));
 

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpReadinessIndicatorTest.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpReadinessIndicatorTest.java
@@ -52,7 +52,8 @@ class WarmUpReadinessIndicatorTest {
 
     @ParameterizedTest
     @MethodSource("getStateParams")
-    void getState(final boolean isUp, final boolean enableReadinessIndicator, final AvailabilityState expected) {
+    void getState(final boolean isUp, final boolean enableReadinessIndicator, final AvailabilityState expected)
+            throws Exception {
         when(factory.getSettings(List.of(initializer))).thenReturn(settings);
         lenient().when(warmUpRunner.isWarmedUp()).thenReturn(isUp);
         lenient().when(settings.enableReadinessIndicator()).thenReturn(enableReadinessIndicator);

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpRunnerTest.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpRunnerTest.java
@@ -34,7 +34,7 @@ class WarmUpRunnerTest {
     private WarmUpRunner warmUpRunner;
 
     @BeforeEach
-    void init() {
+    void setUp() throws Exception {
         warmUpRunner = new WarmUpRunner(List.of(initializer1, initializer2), factory);
         when(factory.getSettings(List.of(initializer1, initializer2))).thenReturn(settings);
     }


### PR DESCRIPTION
This is _technically_ a breaking change (because WarmUpCustomizer has its class hierarchy changed) but clients are not supposed to use the interface that way, so I say it's fine.