### PR TITLE
Call endpoints multiple times if configured

### DIFF
--- a/spring-boot-warmup-core/src/main/java/dev/jeschke/spring/warmup/internal/RepeatingWarmUpSettings.java
+++ b/spring-boot-warmup-core/src/main/java/dev/jeschke/spring/warmup/internal/RepeatingWarmUpSettings.java
@@ -1,0 +1,9 @@
+package dev.jeschke.spring.warmup.internal;
+
+import java.time.Duration;
+
+/**
+ * For internal use only.
+ * @hidden
+ */
+public record RepeatingWarmUpSettings(int times, Duration interval, WarmUpSettings settings) {}

--- a/spring-boot-warmup-core/src/main/java/dev/jeschke/spring/warmup/internal/WarmUpSettings.java
+++ b/spring-boot-warmup-core/src/main/java/dev/jeschke/spring/warmup/internal/WarmUpSettings.java
@@ -1,10 +1,12 @@
-package dev.jeschke.spring.warmup;
+package dev.jeschke.spring.warmup.internal;
 
+import dev.jeschke.spring.warmup.Endpoint;
 import java.net.http.HttpClient;
 import java.util.Collection;
 
 /**
  * For internal use only.
+ * @hidden
  */
 public record WarmUpSettings(
         Collection<Endpoint> endpoints,
@@ -13,4 +15,5 @@ public record WarmUpSettings(
         String protocol,
         HttpClient httpClient,
         String hostname,
-        boolean enableHttpTlsVerification) {}
+        boolean enableHttpTlsVerification,
+        Collection<RepeatingWarmUpSettings> repeatingWarmUpSettings) {}

--- a/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/WarmUpFactory.java
+++ b/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/WarmUpFactory.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNullElseGet;
 
 import dev.jeschke.spring.warmup.builder.WarmUpBuilderImpl;
 import dev.jeschke.spring.warmup.initializers.WarmUpInitializer;
+import dev.jeschke.spring.warmup.internal.WarmUpSettings;
 import java.net.http.HttpClient;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;

--- a/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/initializers/AutomaticEndpointHttpInitializer.java
+++ b/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/initializers/AutomaticEndpointHttpInitializer.java
@@ -4,7 +4,7 @@ import static dev.jeschke.spring.warmup.initializers.AutomaticEndpoint.AUTOMATIC
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import dev.jeschke.spring.warmup.WarmUpFactory;
-import dev.jeschke.spring.warmup.WarmUpSettings;
+import dev.jeschke.spring.warmup.internal.WarmUpSettings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;

--- a/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/initializers/WarmUpInitializer.java
+++ b/spring-boot-warmup-v3/src/main/java/dev/jeschke/spring/warmup/initializers/WarmUpInitializer.java
@@ -1,7 +1,7 @@
 package dev.jeschke.spring.warmup.initializers;
 
 import dev.jeschke.spring.warmup.WarmUpBuilder;
-import dev.jeschke.spring.warmup.WarmUpSettings;
+import dev.jeschke.spring.warmup.internal.WarmUpSettings;
 
 public interface WarmUpInitializer {
 

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/ControllerWarmUpAnnotationTest.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/ControllerWarmUpAnnotationTest.java
@@ -1,11 +1,13 @@
 package dev.jeschke.spring.warmup;
 
 import static dev.jeschke.spring.warmup.application.TestApplication.CUSTOMIZER_TEST_REQUEST_BODY;
+import static dev.jeschke.spring.warmup.application.TestApplication.INIT_CALL_COUNT;
 import static dev.jeschke.spring.warmup.initializers.AutomaticEndpoint.AUTOMATIC_WARM_UP_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.test.context.bean.override.mockito.MockReset.NONE;
@@ -95,6 +97,11 @@ class ControllerWarmUpAnnotationTest {
     @Test
     void automaticWarmUpEndpoint() {
         assertThat(filter.isHitAutomaticEndpoint()).isTrue();
+    }
+
+    @Test
+    void getMultipleTimes() {
+        verify(testMock, times(INIT_CALL_COUNT)).getMultipleTimes();
     }
 
     private TestRequestBody customizerTestRequestBody() {

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpReadinessIndicatorTest.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpReadinessIndicatorTest.java
@@ -8,6 +8,7 @@ import static org.springframework.boot.availability.ReadinessState.ACCEPTING_TRA
 import static org.springframework.boot.availability.ReadinessState.REFUSING_TRAFFIC;
 
 import dev.jeschke.spring.warmup.initializers.WarmUpInitializer;
+import dev.jeschke.spring.warmup.internal.WarmUpSettings;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpRunnerTest.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/WarmUpRunnerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import dev.jeschke.spring.warmup.initializers.WarmUpInitializer;
+import dev.jeschke.spring.warmup.internal.WarmUpSettings;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/application/TestApplication.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/application/TestApplication.java
@@ -6,6 +6,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import dev.jeschke.spring.warmup.ControllerWarmUp;
 import dev.jeschke.spring.warmup.WarmUpConfiguration;
 import dev.jeschke.spring.warmup.WarmUpCustomizer;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Import(WarmUpConfiguration.class)
 public class TestApplication {
     public static final TestRequestBody CUSTOMIZER_TEST_REQUEST_BODY = new TestRequestBody("customizerTestRequestBody");
+    public static final int INIT_CALL_COUNT = 3;
 
     public static void main(final String[] args) {
         SpringApplication.run(TestApplication.class, args);
@@ -35,6 +37,10 @@ public class TestApplication {
             return builder -> builder.addEndpoint("/getByCustomizer")
                     .addEndpoint(
                             POST.name(), "/postByCustomizer", CUSTOMIZER_TEST_REQUEST_BODY, APPLICATION_JSON.toString())
+                    .initializingMultipleTimes(
+                            INIT_CALL_COUNT,
+                            Duration.ofMillis(100),
+                            multipleTimesBuilder -> multipleTimesBuilder.addEndpoint("/getMultipleTimes"))
                     .enableAutomaticMvcWarmUpEndpoint();
         }
     }
@@ -91,6 +97,12 @@ public class TestApplication {
         public String postWithRequestBodyParameter(@RequestBody final InitializedTestRequestBody requestBody) {
             testMock.postWithRequestBodyParameter(requestBody);
             return "postWithRequestBodyParameter";
+        }
+
+        @GetMapping("/getMultipleTimes")
+        public String getMultipleTimes() {
+            testMock.getMultipleTimes();
+            return "getMultipleTimes";
         }
     }
 

--- a/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/application/TestMock.java
+++ b/spring-boot-warmup-v3/src/test/java/dev/jeschke/spring/warmup/application/TestMock.java
@@ -3,7 +3,7 @@ package dev.jeschke.spring.warmup.application;
 import org.springframework.stereotype.Component;
 
 @Component
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "java:S1186"})
 public class TestMock {
 
     public void getNoParams() {}
@@ -19,4 +19,6 @@ public class TestMock {
     public void postWithAnnotationRequestBody(final TestRequestBody body) {}
 
     public void postWithRequestBodyParameter(final TestRequestBody body) {}
+
+    public void getMultipleTimes() {}
 }


### PR DESCRIPTION
This improves warmup for cases where the JVM needs to see multiple calls before optimizing certain access